### PR TITLE
Basic PGEN writer

### DIFF
--- a/src/PGENFiles.jl
+++ b/src/PGENFiles.jl
@@ -4,6 +4,7 @@ import Mmap: mmap
 import Base: unsafe_load
 export Pgen, iterator, n_samples, n_variants, get_genotypes, get_genotypes!
 export alt_allele_dosage, alt_allele_dosage!, ref_allele_dosage, ref_allele_dosage!
+export write_PGEN
 BitIntegers.@define_integers 24
 const variant_type_lengths = Dict(
     0x00 => (4, 1), 0x01 => (4, 2), 0x02 => (4, 3), 0x03 => (4, 4),
@@ -28,5 +29,6 @@ include("difflist.jl")
 include("iterator.jl")
 include("genotype.jl")
 include("dosage.jl")
+include("write.jl")
 datadir(parts...) = joinpath(@__DIR__, "..", "data", parts...)
 end

--- a/src/write.jl
+++ b/src/write.jl
@@ -11,6 +11,7 @@ function write_PGEN(
     variantID::AbstractVector
     )
     n_samples, n_variants = size(x)
+    n_blocks = PGENFiles.ceil_int(n_variants, 2^16) #Int(ceil(n_variants / 2 ^ 16))
     # main PGEN file
     open(pgen_filename, "w") do io
         #
@@ -23,46 +24,66 @@ function write_PGEN(
         # data dimension
         write(io, UInt32(n_variants)) # 6 bytes
         write(io, UInt32(n_samples)) # 10 bytes
-        # what is 11th byte?? 
-        bits_per_record_type = 4
-        bytes_per_record_length = 2
-        write(io, 0x81) # following example in 2.2.6 for now
-        # variant block offsets (i.e. start position for each block)
-        n_blocks = PGENFiles.ceil_int(n_variants, 2^16) #Int(ceil(n_variants / 2 ^ 16))
+        # 11th byte indicating how data is stored
+        bits_per_record_type = 8 # need 8 to encode dosages
+        bytes_per_record_length = 2 # each variant stored as UInt16 (i.e. requiring 2 bytes)
+        twelfth_byte_bits =  "11" * "00" * "0101" # 8 bits per record type, 2 bytes per record length; no allele counts; all ref alleles provisional
+        write(io, bitstring2byte(twelfth_byte_bits))
+        # some constants for computing variant block offsets (i.e. start position for each block)
         variant_offset = 12 + 8n_blocks
         variant_type_offset = Int(2^16 / (8 / bits_per_record_type))
         variant_length_offset = 2^16 * bytes_per_record_length
         variant_offset += (n_blocks - 1) * (variant_type_offset + variant_length_offset)
         last_block_variants = n_variants % 2^16
         variant_offset += Int(last_block_variants / (8 / bits_per_record_type)) + 
-            last_block_variants * bytes_per_record_length # 99325313
-        for b in n_blocks
-            offset = b * variant_offset
-            for x in bytes(variant_offset, len=8, little_endian=true)
+            last_block_variants * bytes_per_record_length # 99325313 if bits_per_record_type = 4; bytes_per_record_length = 2; n_samples = 1092; n_variants = 39728178
+        # store variant offsets for each block, assuming each variant record has fixed width
+        bytes_per_variant_record = 2^16 * bytes_per_record_length * n_samples
+        for b in 1:n_blocks
+            block_offset = variant_offset + (b - 1) * bytes_per_variant_record
+            for x in bytes(block_offset, len=8)
                 write(io, x)
             end
         end
-        # variant record types
+        # store variant record types and variant record lengths for each block.
+        # Here record type is:
+        #   "000" (no compression) +
+        #   "0" (no multi allelic hard calls) +
+        #   "0" (no phased hetero hard calls) +
+        #   "01" (dosage exists for all samples, value of 65535 represents missing) +
+        #   "0" (explicit phased-dosages abscent)
+        variant_record_type_byte = bitstring2byte("00000010")
+        variant_record_length = 0x02 # what should this be? 2 bytes per record length?
+        for b in 1:n_blocks
+            for snp in 1:n_variants
+                write(io, variant_record_type_byte)
+                write(io, variant_record_length)
+            end
+        end
         #
-        # Now handle variant records
+        # Construct variant records 
         #
+        for j in 1:n_variants
+            write_variant_record(io, @view(x[:, j]))
+        end
     end
+    # handle psam file
     # handle pvar file
-    # pvar_filename = joinpath(pgen_filename, )
-    write_pvar(pvar_filneame)
 end
 
-function write_variant_record(io, xi::AbstractVector) # xi is a column of x
-    N = length(xi)
+function write_variant_record(io, xj::AbstractVector) # xj is the jth column of x
+    N = length(xj)
     # track #3, assumes all samples have dosages
-    bytes_written = 0
-    for i in 1:div(N, 8)
-        bytes_written += write(io, 0xff) # 0xff is UInt8 of 11111111
-    end
-    leftover = N % 8
-    bytes_written += write(io, bitstring2byte("1"^leftover * "0"^(8 - leftover)))
+    # bytes_written = 0
+    # for i in 1:div(N, 8)
+    #     bytes_written += write(io, 0xff) # 0xff is UInt8 of 11111111
+    # end
+    # leftover = N % 8
+    # if leftover > 0
+    #     bytes_written += write(io, bitstring2byte("0"^(8 - leftover) * "1"^leftover))
+    # end
     # track #4
-    for xij in xi
+    for xij in xj
         bytes_written += write(io, dosage_to_uint16(xij)) # 2 bytes per entry
     end
     return bytes_written
@@ -71,9 +92,8 @@ end
 function dosage_to_uint16(xij::AbstractFloat, ploidy::Int=2)
     return bytes(round(Int, xij/ploidy * 2^15), len=2)
 end
-
-function write_pvar(pvar_filename)
-    # todo
+function dosage_to_uint16(::Missing, args...)
+    return bytes(65535, len=2)
 end
 
 """
@@ -120,9 +140,11 @@ end
 """
     bitstring2byte(s)
 
-Parse a 8-digit bitstring to an UInt8.
+Parse a 8-digit bitstring (stored in Big endian) to an UInt8.
 
-e.g. bitstring2byte("01110001") = 0x71
+# Examples
++ bitstring2byte("00000001") = 0x01
++ bitstring2byte("01110001") = 0x71
 """
 function bitstring2byte(s::AbstractString)
     @assert length(s) == 8

--- a/src/write.jl
+++ b/src/write.jl
@@ -2,13 +2,33 @@
     write_PGEN(pgen_filename, x, sampleID, variantID)
 
 Saves numeric matrix `x` into a PGEN formatted file. We assume `x`
-stores dosage genotype (i.e. x values are between 0 and 2). 
+stores dosage diploid genotype (i.e. `x[i, j] ∈ [0, 2]`). As such, the code 
+below implements a "fixed-width storage mode" which can write a standalone
+PGEN file in a single sequential pass. 
+
+# Inputs
++ `pgen_filename`: Output filename of PGEN file
++ `x`: Numeric matrix, each row is a sample and each column is a SNPs. It is assumed
+    `x[i, j] ∈ [0, 2]` and missing values are represented using Julia's `Missing` type
+    i.e. `x[i,j] === missing`.
++ `sampleID`: Vector storing each sample's ID
++ `variantID`: Vector storing each variant's ID
+
+# PGEN format structure
+----Header-----
+1. Magic number, storage mode, data dimension
+2. 12th byte: structure of variant record types/length, allele counts, provision ref
+3. Variant block offsets (starting positions of each variant record)
+4. A bunch of blocks, each block storing 2^16 variant record types followed by 2^16 
+    variant record length
+----Variant records-----
+5. Variant record #0 starts here
 """
 function write_PGEN(
     pgen_filename::AbstractString, 
     x::AbstractMatrix,
-    sampleID::AbstractVector,
-    variantID::AbstractVector
+    # sampleID::AbstractVector,
+    # variantID::AbstractVector
     )
     n_samples, n_variants = size(x)
     n_blocks = PGENFiles.ceil_int(n_variants, 2^16) #Int(ceil(n_variants / 2 ^ 16))
@@ -27,7 +47,7 @@ function write_PGEN(
         # 11th byte indicating how data is stored
         bits_per_record_type = 8 # need 8 to encode dosages
         bytes_per_record_length = 2 # each variant stored as UInt16 (i.e. requiring 2 bytes)
-        twelfth_byte_bits =  "11" * "00" * "0101" # 8 bits per record type, 2 bytes per record length; no allele counts; all ref alleles provisional
+        twelfth_byte_bits =  "10" * "00" * "0101" # all ref alleles provisional; no allele counts; 8 bits per record type, 2 bytes per record length; 
         write(io, bitstring2byte(twelfth_byte_bits))
         # some constants for computing variant block offsets (i.e. start position for each block)
         variant_offset = 12 + 8n_blocks
@@ -41,7 +61,7 @@ function write_PGEN(
         bytes_per_variant_record = 2^16 * bytes_per_record_length * n_samples
         for b in 1:n_blocks
             block_offset = variant_offset + (b - 1) * bytes_per_variant_record
-            for x in bytes(block_offset, len=8)
+            for x in int2bytes(block_offset, len=8)
                 write(io, x)
             end
         end
@@ -53,11 +73,11 @@ function write_PGEN(
         #   "01" (dosage exists for all samples, value of 65535 represents missing) +
         #   "0" (explicit phased-dosages abscent)
         variant_record_type_byte = bitstring2byte("00000010")
-        variant_record_length = 0x02 # what should this be? 2 bytes per record length?
+        variant_record_byte_length = int2bytes(bytes_per_record_length * n_samples, len=2)
         for b in 1:n_blocks
             for snp in 1:n_variants
                 write(io, variant_record_type_byte)
-                write(io, variant_record_length)
+                write(io, variant_record_byte_length)
             end
         end
         #
@@ -73,16 +93,8 @@ end
 
 function write_variant_record(io, xj::AbstractVector) # xj is the jth column of x
     N = length(xj)
-    # track #3, assumes all samples have dosages
-    # bytes_written = 0
-    # for i in 1:div(N, 8)
-    #     bytes_written += write(io, 0xff) # 0xff is UInt8 of 11111111
-    # end
-    # leftover = N % 8
-    # if leftover > 0
-    #     bytes_written += write(io, bitstring2byte("0"^(8 - leftover) * "1"^leftover))
-    # end
     # track #4
+    bytes_written = 0
     for xij in xj
         bytes_written += write(io, dosage_to_uint16(xij)) # 2 bytes per entry
     end
@@ -90,14 +102,14 @@ function write_variant_record(io, xj::AbstractVector) # xj is the jth column of 
 end
 
 function dosage_to_uint16(xij::AbstractFloat, ploidy::Int=2)
-    return bytes(round(Int, xij/ploidy * 2^15), len=2)
+    return int2bytes(round(Int, xij/ploidy * 2^15), len=2)
 end
 function dosage_to_uint16(::Missing, args...)
-    return bytes(65535, len=2)
+    return int2bytes(65535, len=2)
 end
 
 """
-    bytes(x::Integer; len::Integer, little_endian::Bool)
+int2bytes(x::Integer; len::Integer, little_endian::Bool)
     -> Vector{len, UInt8}
 
 Convert an Integer `x` to a Vector{UInt8}
@@ -106,17 +118,17 @@ Options (not available for `x::BigInt`):
 zero by default.
 - set `little_endian` to `true` for a result in little endian byte order, result
 in big endian order by default.
-    julia> bytes(32974)
+    julia> int2bytes(32974)
     2-element Array{UInt8,1}:
      0x80
      0xce
-    julia> bytes(32974, len=4)
+    julia> int2bytes(32974, len=4)
     4-element Array{UInt8,1}:
      0x00
      0x00
      0x80
      0xce
-    julia> bytes(32974, little_endian=true)
+    julia> int2bytes(32974, little_endian=true)
     2-element Array{UInt8,1}:
      0xce
      0x80
@@ -124,7 +136,7 @@ in big endian order by default.
 # Source
 https://github.com/roshii/BitConverter.jl/blob/master/src/BitConverter.jl
 """
-function bytes(x::Integer; len::Integer=0, little_endian::Bool=true)
+function int2bytes(x::Integer; len::Integer=0, little_endian::Bool=true)
     result = reinterpret(UInt8, [hton(x)])
     i = findfirst(x -> x != 0x00, result)
     if len != 0

--- a/src/write.jl
+++ b/src/write.jl
@@ -68,13 +68,13 @@ function write_PGEN(
         end
         # store variant record types and variant record lengths for each block.
         # Here record type is:
-        #   "000" (no compression) +
-        #   "0" (no multi allelic hard calls) +
+        #   "0" (explicit phased-dosages abscent) + 
+        #   "10" (dosage exists for all samples, value of 65535 represents missing) +
         #   "0" (no phased hetero hard calls) +
-        #   "01" (dosage exists for all samples, value of 65535 represents missing) +
-        #   "0" (explicit phased-dosages abscent)
-        variant_record_type = bitstring2byte("00000010")
-        variant_record_byte_length = int2bytes(bytes_per_record_length * n_samples, len=2)
+        #   "0" (no multi allelic hard calls) +
+        #   "000" (no compression)
+        variant_record_type = bitstring2byte("01000000")
+        variant_record_byte_length = int2bytes(bytes_per_record_length * n_samples, len=2) # bytes_per_record_length = 2; n_samples = 500; this gives [0xe8, 0x03]
         for b in 1:(n_blocks - 1)
             for snp in 1:2^16
                 bytes_written += write(io, variant_record_type)

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,0 +1,102 @@
+"""
+    write_PGEN(pgen_filename, x, sampleID, variantID)
+
+Saves numeric matrix `x` into a PGEN formatted file. We assume `x`
+stores dosage genotype (i.e. x values are between 0 and 2). 
+"""
+function write_PGEN(
+    pgen_filename::AbstractString, 
+    x::AbstractMatrix,
+    sampleID::AbstractVector,
+    variantID::AbstractVector
+    )
+    n_samples, n_variants = size(x)
+    # main PGEN file
+    open(pgen_filename, "w") do io
+        #
+        # Construct header
+        #
+        # magic number
+        write(io, 0x6c, 0x1b)
+        # storage mode
+        write(io, 0x10) # 2 bytes so far (note: 0-based indexing according to manual) 
+        # data dimension
+        write(io, UInt32(n_variants)) # 6 bytes
+        write(io, UInt32(n_samples)) # 10 bytes
+        # what is 11th byte?? 
+        bits_per_record_type = 4
+        bytes_per_record_length = 2
+        write(io, 0x81) # following example in 2.2.6 for now
+        # variant block offsets (i.e. start position for each block)
+        n_blocks = PGENFiles.ceil_int(n_variants, 2^16) #Int(ceil(n_variants / 2 ^ 16))
+        variant_offset = 12 + 8n_blocks
+        variant_type_offset = Int(2^16 / (8 / bits_per_record_type))
+        variant_length_offset = 2^16 * bytes_per_record_length
+        variant_offset += (n_blocks - 1) * (variant_type_offset + variant_length_offset)
+        last_block_variants = n_variants % 2^16
+        variant_offset += Int(last_block_variants / (8 / bits_per_record_type)) + 
+            last_block_variants * bytes_per_record_length # 99325313
+        for b in n_blocks
+            offset = b * variant_offset
+            for x in bytes(variant_offset, len=8, little_endian=true)
+                write(io, x)
+            end
+        end
+        # variant record types
+        #
+        # Now handle variant records
+        #
+    end
+    # handle pvar file
+    # pvar_filename = joinpath(pgen_filename, )
+    write_pvar(pvar_filneame)
+end
+
+# using PGENFiles
+# n_samples = 1092
+# n_variants = 39728178
+
+function write_pvar(pvar_filename)
+    # todo
+end
+
+"""
+    bytes(x::Integer; len::Integer, little_endian::Bool)
+    -> Vector{len, UInt8}
+
+Convert an Integer `x` to a Vector{UInt8}
+Options (not available for `x::BigInt`):
+- `len` to define a minimum Vector lenght in bytes, result will show no leading
+zero by default.
+- set `little_endian` to `true` for a result in little endian byte order, result
+in big endian order by default.
+    julia> bytes(32974)
+    2-element Array{UInt8,1}:
+     0x80
+     0xce
+    julia> bytes(32974, len=4)
+    4-element Array{UInt8,1}:
+     0x00
+     0x00
+     0x80
+     0xce
+    julia> bytes(32974, little_endian=true)
+    2-element Array{UInt8,1}:
+     0xce
+     0x80
+
+# Source
+https://github.com/roshii/BitConverter.jl/blob/master/src/BitConverter.jl
+"""
+function bytes(x::Integer; len::Integer=0, little_endian::Bool=false)
+    result = reinterpret(UInt8, [hton(x)])
+    i = findfirst(x -> x != 0x00, result)
+    if len != 0
+        i = length(result) - len + 1
+    end
+    result = result[i:end]
+    if little_endian
+        reverse!(result)
+    end
+    return result
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,9 +164,11 @@ end
     bfile = Bgen(PGENFiles.datadir("example.16bits.bgen"))
     bgenG, nsamples, Gchr, Gpos, GsnpID, Gref, Galt = convert_gt(Float64, bfile)
     # pgenG = convert_gt(Float64, PGENFiles.Pgen(data))
-    write_PGEN("test_pgen_write.pgen", bgenG)
+    write_PGEN("test_pgen_write", bgenG)
     pgenG = convert_gt(Float64, PGENFiles.Pgen("test_pgen_write.pgen"))
     @test all(isapprox.(pgenG, bgenG; atol=5e-5, nans=true))
     rm("test_pgen_write.pgen", force=true)
+    rm("test_pgen_write.pvar", force=true)
+    rm("test_pgen_write.psam", force=true)
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,61 @@ using Test, BGEN
 const data = PGENFiles.datadir("bgen_example.16bits.pgen")
 @testset "PGENFiles.jl" begin
 
+function convert_gt(t::Type{T}, b::Bgen) where T <: Real
+    n = BGEN.n_samples(b)
+    p = BGEN.n_variants(b)
+
+    # return arrays
+    G = Matrix{t}(undef, n, p)
+    Gchr = Vector{String}(undef, p)
+    Gpos = Vector{Int}(undef, p)
+    GsnpID = [String[] for _ in 1:p] # each variant can have >1 rsid, although we don't presently allow this
+    Gref = Vector{String}(undef, p)
+    Galt = [String[] for _ in 1:p] # each variant can have >1 alt allele, although we don't presently allow this
+
+    # loop over each variant
+    i = 1
+    for v in BGEN.iterator(b; from_bgen_start=true)
+        dose = first_allele_dosage!(b, v; T=t) # this reads REF allele as 1
+        copyto!(@view(G[:, i]), dose)
+        # store chr/pos/snpID/ref/alt info
+        Gchr[i], Gpos[i] = chrom(v), pos(v)
+        push!(GsnpID[i], rsid(v))
+        ref_alt_alleles = alleles(v)
+        length(ref_alt_alleles) > 2 && error("Marker $i of BGEN is not biallelic!")
+        Gref[i] = ref_alt_alleles[1]
+        push!(Galt[i], ref_alt_alleles[2])
+        i += 1
+        clear!(v)
+    end
+
+    return G, b.samples, Gchr, Gpos, GsnpID, Gref, Galt
+end
+
+function convert_gt(t::Type{T}, pfile::Pgen) where T <: Real
+    n = PGENFiles.n_samples(pfile) |> Int
+    p = PGENFiles.n_variants(pfile) |> Int
+
+    # return arrays
+    G = Matrix{t}(undef, n, p)
+
+    # loop over each variant
+    d = Vector{t}(undef, n)
+    g = Vector{UInt8}(undef, n)
+    g_ld = similar(g)
+    for (j, v) in enumerate(PGENFiles.iterator(pfile))
+        alt_allele_dosage!(d, g, pfile, v; genoldbuf=g_ld)
+        v_rt = v.record_type & 0x07
+        if v_rt != 0x02 && v_rt != 0x03 # non-LD-compressed. See Format description.
+            g_ld .= g
+        end
+        # store dosages
+        G[:, j] .= d
+    end
+
+    return G
+end
+
 @testset "Header" begin
     p = PGENFiles.Pgen(data)
     h = p.header
@@ -90,5 +145,57 @@ end
             g_pgen_ld .= g_pgen
         end
     end
+end
+
+@testset "write PGEN" begin    
+    # bitstring2byte function
+    @test bitstring2byte("01110001") == 0x71
+    @test bitstring2byte("11111111") == 0xff
+
+    # bytes function (example at 2.2.6)
+    @test PGENFiles.bytes(99325313, len=8) == [0x81, 0x95, 0xeb, 0x05, 0x00, 0x00, 0x00, 0x00]
+
+    # dosage_to_uint16 function (example at end of 2.3.5)
+    ploidy = 2
+    @test PGENFiles.dosage_to_uint16(0.75, ploidy) == [0x00, 0x30]
+    @test PGENFiles.dosage_to_uint16(1.5, ploidy) == [0x00, 0x60]
+
+    # write_variant_record function (example at end of 2.3.5, modified so all samples have dosages)
+    N = 488377
+    xj = fill(0.75, N)
+    xj[10000] = 1.5
+    open("test_io_file", "w") do io
+        b = PGENFiles.write_variant_record(io, xj)
+    end
+    result = open("test_io_file") do io
+        read(io)
+    end
+    rm("test_io_file", force=true)
+    @test result[1:61047] == fill(0xff, 61047)
+    @test result[61048] == 
+    for i in 1:9999
+        @test result[61049+2(i-1) : 61049+2(i-1)+1] == [0x00, 0x30]
+    end
+    @test result[61049+2(10000-1) : 61049+2(10000-1)+1] == [0x00, 0x60]
+    for i in 10001:N
+        @test result[61049+2(i-1) : 61049+2(i-1)+1] == [0x00, 0x30]
+    end
+
+    # write_variant_record function (test if each block have fixed number of bytes)
+    io = open("test_io_file", "w")
+    n_samples = 800
+    xj = 2rand(n_samples)
+    b = PGENFiles.write_variant_record(io, xi) # b is 1700
+    close(io); rm("test_io_file", force=true);
+    @test 2^16 * b == 111411200
+
+    # write_PGEN function
+    bfile = Bgen(PGENFiles.datadir("example.16bits.bgen"))
+    bgenG, nsamples, Gchr, Gpos, GsnpID, Gref, Galt = convert_gt(Float64, bfile)
+    # pgenG = convert_gt(Float64, PGENFiles.Pgen(data))
+    write_PGEN("test_pgen_write.pgen", bgenG)
+    pgenG = convert_gt(Float64, PGENFiles.Pgen("test_pgen_write.pgen"))
+    @test all(isapprox.(pgenG, bgenG; atol=5e-5, nans=true))
+    rm("test_pgen_write.pgen", force=true)
 end
 end


### PR DESCRIPTION
This pr adds the `write_pgen` functionality which saves a dosage matrix into a PGEN file. Any suggestion is highly appreciated. 

+ In `write_pgen`, all hard-call genotypes are missing, while dosage values are saved in data track 4 of variant records
+ Currently `write_pgen` is about ~6x slower than reading variant by variant, but I'm not sure how to optimize further. This line takes up roughly 70% of the time but I'm not sure if we can replace it with anything else
https://github.com/OpenMendel/PGENFiles.jl/blob/ba323234e1806e152189c29c16b154eed37a4af2/src/write.jl#L197
+ `psam` and `pvar` files are also outputted. I'm not sure if it's better to output a `pvar.zst` instead, but that would require adding `CodecZlib.jl` as another dependency

If this seems fine, I still need to add some documentation