### PR TITLE
Fix collect for PgenVariantIterator to return unique variants

### DIFF
--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -38,6 +38,17 @@ end
     (vi.p.header.n_variants, )
 end
 
+# Overload collect for PgenVariantIterator
+function Base.collect(vi::PgenVariantIterator)
+    result = Vector{Variant}(undef, length(vi))
+    i = 1
+    for v in vi
+        result[i] = PgenVariant(v.index, v.offset, v.record_type, v.length)
+        i += 1
+    end
+    return result
+end
+
 """
     iterator(p::Pgen; startidx=1)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,4 +99,18 @@ end
         @test all([p.pvar_df[v_pgen.index, :REF], p.pvar_df[v_pgen.index, :ALT]] .== GeneticVariantBase.alleles(p, v_pgen))
     end
 end
+    
+@testset "Custom collect for PgenVariantIterator" begin
+    # Setup PGEN file and iterator
+    p = PGENFiles.Pgen(data)  # Replace with a valid test file
+    v_iter = iterator(p)
+
+    # Collect variants
+    variants = collect(v_iter)
+
+    # Check that variants are unique
+    @test length(variants) == p.header.n_variants
+    @test all(v != variants[end] for v in variants[1:end-1])
+end   
+    
 end


### PR DESCRIPTION
This PR overloads `Base.collect` for `PgenVariantIterator` to ensure it returns an array of unique `PgenVariant` objects.

The original `collect` behavior reused the same object, leading to unexpected results where all elements in the collected array were references to the last variant. This fix introduces a specialized `collect` implementation that creates a new `PgenVariant` object for each iteration.

### Changes
- Added a `Base.collect` overload for `PgenVariantIterator`.
- Included tests to verify the correctness of the fix.

Let me know if any further modifications are needed!
