### PR TITLE
Fix 24 bit int arrays for Julia 1.14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,38 +29,28 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-${{ matrix.arch }}-test-
-            ${{ runner.os }}-${{ matrix.arch }}-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - run: |
           git config --global user.name Tester
           git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v7
         with:
-          file: lcov.info
+          files: lcov.info
 
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,12 @@ authors = ["Seyoon Ko <kos@ucla.edu> and contributors"]
 version = "0.2.2"
 
 [deps]
-BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GeneticVariantBase = "2447270c-d849-4bf9-ac0d-b5c0b265991c"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [compat]
-BitIntegers = "0.2, 0.3"
 CSV = "0.10"
 DataFrames = "1"
 GeneticVariantBase = "0.1.2"

--- a/src/PGENFiles.jl
+++ b/src/PGENFiles.jl
@@ -1,5 +1,4 @@
 module PGENFiles
-using BitIntegers
 using CSV, DataFrames
 import Mmap: mmap
 import Base: unsafe_load
@@ -8,12 +7,12 @@ import GeneticVariantBase: chrom, pos, rsid, alleles, alt_allele, ref_allele
 import GeneticVariantBase: maf, hwepval, infoscore, alt_dosages!
 export Pgen, iterator, n_samples, n_variants, get_genotypes, get_genotypes!
 export alt_allele_dosage, alt_allele_dosage!, ref_allele_dosage, ref_allele_dosage!
-BitIntegers.@define_integers 24
 const variant_type_lengths = Dict(
     0x00 => (4, 1), 0x01 => (4, 2), 0x02 => (4, 3), 0x03 => (4, 4),
     0x04 => (8, 1), 0x05 => (8, 2), 0x06 => (8, 3), 0x07 => (8, 4)
 )
-const bytes_to_UInt = Dict(0x01 => UInt8, 0x02 => UInt16, 0x03 => UInt24, 0x04 => UInt32, 0x08 => UInt64)
+# width 3 maps to UInt32: packed 3-byte records are read through PackedUInt24Vector
+const bytes_to_UInt = Dict(0x01 => UInt8, 0x02 => UInt16, 0x03 => UInt32, 0x04 => UInt32, 0x08 => UInt64)
 const mask_map = [0x01, 0x03, 0x00, 0x0f, 0x00, 0x00, 0x00, 0xff]
 
 @inline ceil_int(x::Integer, y::Integer) = (x ÷ y) + (x % y != 0)

--- a/src/difflist.jl
+++ b/src/difflist.jl
@@ -13,11 +13,11 @@ function parse_difflist(data::AbstractVector{UInt8},
     sample_id_dtype = bytes_to_UInt[bytes_per_sample_id]
     if len == 0
         return DiffList{sample_id_dtype, Nothing}(
-            0, C_NULL, C_NULL, has_genotype, nothing, C_NULL), offset
+            0, zero(sample_id_dtype), C_NULL, has_genotype, nothing, C_NULL), offset
     end
     # sample id bases
     n_groups = ceil_int(len, 0x000040) # 64 in decimal
-    sample_id_bases = reinterpret(sample_id_dtype, view(data, 
+    sample_id_bases = reinterpret_track(bytes_per_sample_id, view(data,
         Int(offset + 1) : Int(offset + n_groups * bytes_per_sample_id)))
 
     offset += n_groups * bytes_per_sample_id

--- a/src/header.jl
+++ b/src/header.jl
@@ -73,7 +73,7 @@ function Header(io::IOStream)
 
         # read variant record length track
         arr = read(io, block_size * bytes_per_record_length) #data[offset + 1 : offset + block_size * bytes_per_record_length]
-        reinterpreted = reinterpret(dtype_variant_length, arr)
+        reinterpreted = reinterpret_track(bytes_per_record_length, arr)
         t_variant_sizes = typeof(reinterpreted)
         push!(sectors_variant_lengths, Ref(reinterpreted))
         offset += bytes_per_record_length * block_size 
@@ -82,7 +82,7 @@ function Header(io::IOStream)
         if sectors_allele_counts !== nothing
             arr = read(io, block_size * bytes_allele_counts)
             #arr = data[offset + 1:offset + block_size * bytes_allele_counts]
-            reinterpreted = reinterpret(dtype_allele_counts, arr)
+            reinterpreted = reinterpret_track(bytes_allele_counts, arr)
             t_allele_counts = typeof(reinterpreted)
             push!(sectors_allele_counts, Ref(reinterpreted))
             offset += bytes_allele_counts * block_size

--- a/src/internal_structs.jl
+++ b/src/internal_structs.jl
@@ -61,6 +61,42 @@ end
 end
 
 """
+    PackedUInt24Vector(data)
+
+Lazy vector of packed 3-byte little-endian unsigned integers over the byte
+buffer `data`, widened to `UInt32` on access. Used in place of
+`reinterpret(UInt24, data)`: 24-bit primitive types are padded to 4 bytes in
+memory (as of Julia 1.14, matching C's `_BitInt`), so they cannot represent
+the packed 3-byte records in a pgen file.
+"""
+struct PackedUInt24Vector{V<:AbstractVector{UInt8}} <: AbstractVector{UInt32}
+    data::V
+end
+
+Base.size(x::PackedUInt24Vector) = (length(x.data) ÷ 3,)
+Base.IndexStyle(::Type{<:PackedUInt24Vector}) = IndexLinear()
+
+Base.@propagate_inbounds function Base.getindex(x::PackedUInt24Vector, i::Int)
+    @boundscheck checkbounds(x, i)
+    j = 3 * (i - 1)
+    @inbounds UInt32(x.data[begin + j]) | UInt32(x.data[begin + j + 1]) << 8 | UInt32(x.data[begin + j + 2]) << 16
+end
+
+"""
+    reinterpret_track(width, data)
+
+Interpret the byte buffer `data` as a vector of packed `width`-byte
+little-endian unsigned integers, without copying.
+"""
+function reinterpret_track(width::Integer, data::AbstractVector{UInt8})
+    if width == 3
+        PackedUInt24Vector(data)
+    else
+        reinterpret(bytes_to_UInt[width], data)
+    end
+end
+
+"""
     DiffList{V,W,X,Y}(len, sample_id_bases, last_component_sizes, has_genotypes, 
     genotypes, sample_id_increments)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,23 @@ using GeneticVariantBase
 const data = PGENFiles.datadir("bgen_example.16bits.pgen")
 @testset "PGENFiles.jl" begin
 
+@testset "reinterpret_track" begin
+    # packed 3-byte little-endian records: [0x000001, 0xABCDEF, 0xFFFFFF]
+    bytes = UInt8[0x01, 0x00, 0x00, 0xEF, 0xCD, 0xAB, 0xFF, 0xFF, 0xFF]
+    v = PGENFiles.reinterpret_track(3, bytes)
+    @test v isa PGENFiles.PackedUInt24Vector
+    @test eltype(v) == UInt32
+    @test length(v) == 3
+    @test collect(v) == UInt32[0x000001, 0xABCDEF, 0xFFFFFF]
+    @test_throws BoundsError v[4]
+    @test PGENFiles.reinterpret_track(1, bytes) == bytes
+    @test PGENFiles.reinterpret_track(2, UInt8[0x34, 0x12]) == UInt16[0x1234]
+    @test PGENFiles.reinterpret_track(4, UInt8[0x78, 0x56, 0x34, 0x12]) ==
+        UInt32[0x12345678]
+    @test PGENFiles.reinterpret_track(8, UInt8[0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0xFF]) ==
+        UInt64[0xFF000000_12345678]
+end
+
 @testset "Header" begin
     p = PGENFiles.Pgen(data)
     h = p.header


### PR DESCRIPTION
In Julia 1.14 reinterpret behaves correctly for primitives with padding. However this package was relying on those bugs.

This PR fixes this package for Julia 1.14.
XRef: https://github.com/JuliaLang/julia/issues/62894

Assisted-by: Claude Code (Fable 5)